### PR TITLE
add infrastructure for a -m32 switch

### DIFF
--- a/src/d/llvm/codegen.d
+++ b/src/d/llvm/codegen.d
@@ -201,22 +201,22 @@ final class DruntimeGen {
 	
 	auto getAssert() {
 		// TODO: LLVMAddFunctionAttr(fun, LLVMAttribute.NoReturn);
-		return getNamedFunction("_d_assert", LLVMFunctionType(LLVMVoidTypeInContext(llvmCtx), [LLVMStructTypeInContext(llvmCtx, [LLVMInt64TypeInContext(llvmCtx), LLVMPointerType(LLVMInt8TypeInContext(llvmCtx), 0)].ptr, 2, false), LLVMInt32TypeInContext(llvmCtx)].ptr, 2, false));
+		return getNamedFunction("_d_assert", LLVMFunctionType(LLVMVoidTypeInContext(llvmCtx), [LLVMStructTypeInContext(llvmCtx, [LLVMIntPtrTypeInContext(llvmCtx, targetData), LLVMPointerType(LLVMInt8TypeInContext(llvmCtx), 0)].ptr, 2, false), LLVMInt32TypeInContext(llvmCtx)].ptr, 2, false));
 	}
 	
 	auto getAssertMessage() {
 		// TODO: LLVMAddFunctionAttr(fun, LLVMAttribute.NoReturn);
-		return getNamedFunction("_d_assert_msg", LLVMFunctionType(LLVMVoidTypeInContext(llvmCtx), [LLVMStructTypeInContext(llvmCtx, [LLVMInt64TypeInContext(llvmCtx), LLVMPointerType(LLVMInt8TypeInContext(llvmCtx), 0)].ptr, 2, false), LLVMStructTypeInContext(llvmCtx, [LLVMInt64TypeInContext(llvmCtx), LLVMPointerType(LLVMInt8TypeInContext(llvmCtx), 0)].ptr, 2, false), LLVMInt32TypeInContext(llvmCtx)].ptr, 3, false));
+		return getNamedFunction("_d_assert_msg", LLVMFunctionType(LLVMVoidTypeInContext(llvmCtx), [LLVMStructTypeInContext(llvmCtx, [LLVMIntPtrTypeInContext(llvmCtx, targetData), LLVMPointerType(LLVMInt8TypeInContext(llvmCtx), 0)].ptr, 2, false), LLVMStructTypeInContext(llvmCtx, [LLVMIntPtrTypeInContext(llvmCtx, targetData), LLVMPointerType(LLVMInt8TypeInContext(llvmCtx), 0)].ptr, 2, false), LLVMInt32TypeInContext(llvmCtx)].ptr, 3, false));
 	}
 	
 	auto getArrayBound() {
 		// TODO: LLVMAddFunctionAttr(fun, LLVMAttribute.NoReturn);
-		return getNamedFunction("_d_arraybounds", LLVMFunctionType(LLVMVoidTypeInContext(llvmCtx), [LLVMStructTypeInContext(llvmCtx, [LLVMInt64TypeInContext(llvmCtx), LLVMPointerType(LLVMInt8TypeInContext(llvmCtx), 0)].ptr, 2, false), LLVMInt32TypeInContext(llvmCtx)].ptr, 2, false));
+		return getNamedFunction("_d_arraybounds", LLVMFunctionType(LLVMVoidTypeInContext(llvmCtx), [LLVMStructTypeInContext(llvmCtx, [LLVMIntPtrTypeInContext(llvmCtx, targetData), LLVMPointerType(LLVMInt8TypeInContext(llvmCtx), 0)].ptr, 2, false), LLVMInt32TypeInContext(llvmCtx)].ptr, 2, false));
 	}
 	
 	auto getAllocMemory() {
 		return getNamedFunction("_d_allocmemory", (p) {
-			auto arg = LLVMInt64TypeInContext(p.llvmCtx);
+			auto arg = LLVMIntPtrTypeInContext(p.llvmCtx, p.targetData);
 			auto type = LLVMFunctionType(LLVMPointerType(LLVMInt8TypeInContext(p.llvmCtx), 0), &arg, 1, false);
 			auto fun = LLVMAddFunction(p.dmodule, "_d_allocmemory", type);
 			

--- a/src/d/llvm/string.d
+++ b/src/d/llvm/string.d
@@ -3,6 +3,7 @@ module d.llvm.string;
 import d.llvm.codegen;
 
 import llvm.c.core;
+import llvm.c.target;
 
 import std.string;
 
@@ -28,11 +29,11 @@ final class StringGen {
 			LLVMSetLinkage(globalVar, LLVMLinkage.Private);
 			LLVMSetGlobalConstant(globalVar, true);
 			
-			auto length = LLVMConstInt(LLVMInt64TypeInContext(pass.llvmCtx), str.length, false);
+			auto length = LLVMConstInt(LLVMIntPtrTypeInContext(pass.llvmCtx, pass.targetData), str.length, false);
 			
 			/*
 			// skip 0 termination.
-			auto indices = [LLVMConstInt(LLVMInt64TypeInContext(pass.llvmCtx), 0, true), LLVMConstInt(LLVMInt64TypeInContext(pass.llvmCtx), 0, true)];
+			auto indices = [LLVMConstInt(LLVMIntPtrTypeInContext(pass.llvmCtx, pass.targetData), 0, true), LLVMConstInt(LLVMIntPtrTypeInContext(pass.llvmCtx, pass.targetData), 0, true)];
 			auto ptr = LLVMBuildInBoundsGEP(pass.builder, globalVar, indices.ptr, 2, "");
 			/*/
 			// with 0 termination.

--- a/src/d/llvm/type.d
+++ b/src/d/llvm/type.d
@@ -10,6 +10,7 @@ import d.exception;
 import util.visitor;
 
 import llvm.c.core;
+import llvm.c.target;
 
 import std.algorithm;
 import std.array;
@@ -100,7 +101,7 @@ final class TypeGen {
 	
 	LLVMTypeRef visitSliceOf(Type t) {
 		LLVMTypeRef[2] types;
-		types[0] = LLVMInt64TypeInContext(llvmCtx);
+		types[0] = LLVMIntPtrTypeInContext(llvmCtx, targetData);
 		types[1] = visitPointerOf(t);
 		
 		return LLVMStructTypeInContext(llvmCtx, types.ptr, 2, false);


### PR DESCRIPTION
Yep,
I got every oblivious hard-coded 64bit-types and made it possible to vary their bit-widths at runtime.
However there are a few regressions and they are related newExperession. The parameter for `_d_allocmemory` always get's casted to an i64. I spent a few hours tracking down this problem but I can't fix it. EDIT its `LLVMSizeOf`

Regards, Stefan
  